### PR TITLE
feat(serverConfig) allow loading server configs from directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 dist/
+serverConfigs/

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ userDataTemplates:
     package_upgrade: true
     ssh_pwauth: false
 
+serverConfigPath: "serverConfigs"
 serverConfigs:
 - name: "basic-dev"
   matchPatterns:


### PR DESCRIPTION
Currently it's only possible to add serverConfigs to the regular config yaml.

As I'm managing my VMs using Ansible, it would be easier to just create a file for each VM and not write it all to the same config file.

This pull requests add a new configuration value `serverConfigPath` where each y(a)ml file within is read and added to the serverConfig list.